### PR TITLE
Implementada dualidad de uso: modos Entrenamiento y Simulacro con roles filtrados

### DIFF
--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,34 +1,60 @@
 // src/components/Dashboard/Dashboard.tsx
-import React from "react";
+import React, { useState } from "react";
+import { ModoSimulador } from "../../types/dualidad";
 
-const Dashboard: React.FC<{ onStart: () => void }> = ({ onStart }) => (
-  <div className="card card-max card-centered flex-column text-center">
-    <h1>Simulador de Emergencias ER-Simulator</h1>
-    <p>
-      Bienvenido al simulador avanzado de derrames en el litoral andaluz. Elige
-      tu rol, define condiciones ambientales y gestiona la emergencia según la
-      normativa real.
-    </p>
-    <button onClick={onStart}>Empezar Simulación</button>
-    <div className="mt-2">
-      <a
-        href="https://www.boe.es/buscar/doc.php?id=BOE-A-2012-15482"
-        target="_blank"
-        rel="noopener noreferrer"
+const Dashboard: React.FC<{ onStart: (modo: ModoSimulador) => void }> = ({
+  onStart,
+}) => {
+  const [modo, setModo] = useState<ModoSimulador | null>(null);
+
+  return (
+    <div className="card card-max card-centered flex-column text-center">
+      <h1>Simulador de Emergencias ER-Simulator</h1>
+      <p>
+        Bienvenido al simulador avanzado de derrames en el litoral andaluz.
+        Elige el modo de uso y gestiona la emergencia según la normativa real.
+      </p>
+      <div className="dashboard-links dashboard-modos">
+        <button
+          className={`btn-accent${modo === "entrenamiento" ? " selected" : ""}`}
+          onClick={() => setModo("entrenamiento")}
+        >
+          Entrenamiento
+        </button>
+        <button
+          className={`btn-accent${modo === "simulacro" ? " selected" : ""}`}
+          onClick={() => setModo("simulacro")}
+        >
+          Simulacro real / Coordinación
+        </button>
+      </div>
+      <button
+        className="btn-success"
+        onClick={() => modo && onStart(modo)}
+        disabled={!modo}
       >
-        Consultar Real Decreto 1695/2012
-      </a>
+        Empezar
+      </button>
+      <div className="mt-2">
+        <a
+          href="https://www.boe.es/buscar/doc.php?id=BOE-A-2012-15482"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Consultar Real Decreto 1695/2012
+        </a>
+      </div>
+      <div className="mt-2">
+        <a
+          href="https://www.juntadeandalucia.es/medioambiente/servtc5/pecla/pecla.htm"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Ver PECLA Andalucía
+        </a>
+      </div>
     </div>
-    <div className="mt-2">
-      <a
-        href="https://www.juntadeandalucia.es/medioambiente/servtc5/pecla/pecla.htm"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Ver PECLA Andalucía
-      </a>
-    </div>
-  </div>
-);
+  );
+};
 
 export default Dashboard;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,12 +6,33 @@ import SimulacionMain from "../components/SimulacionMain/SimulacionMain";
 import { ROLES_INFO } from "../utils/rolesData";
 import Dashboard from "../components/Dashboard/Dashboard";
 import RoleDropdown from "../components/RoleSelector/RoleDropdown";
-import { DerrameCoords, RolInfo } from "../types/simulacro";
+import { DerrameCoords, RolInfo, RolSimulacro } from "../types/simulacro";
+import { ModoSimulador } from "../types/dualidad";
 
 // Dynamic import para MapCard (Leaflet, evitar SSR)
 const MapCard = dynamic(() => import("../components/UI/MapCard"), {
   ssr: false,
 });
+
+const ROLES_ENTRENAMIENTO: RolSimulacro[] = [
+  "CAPITAN_BARCO_A",
+  "CAPITAN_BARCO_B",
+  "ARMADOR_A",
+  "ARMADOR_B",
+  "FLETADOR_A",
+  "FLETADOR_B",
+  "TERMINAL_MOEVE",
+  "GABINETE_FABRICA",
+  "GABINETE_TRADING",
+  "CAPITANIA",
+  "PECLA",
+  "EMERGENCIAS_112",
+];
+const ROLES_SIMULACRO: RolSimulacro[] = [
+  "ORGANIZADOR",
+  "OBSERVADOR",
+  "LIDER_SIMULACRO",
+];
 
 export default function LandingSimulacro() {
   const {
@@ -20,22 +41,23 @@ export default function LandingSimulacro() {
     condiciones,
     setCondiciones,
     resetSimulacro,
-    setDerrameCoords, // <-- asegúrate de tener esto
+    setDerrameCoords,
     derrameCoords,
   } = useSimulacro();
 
-  // Nuevos estados para el flujo
   const [showDashboard, setShowDashboard] = useState(true);
   const [derrCoords, setDerrCoords] = useState<DerrameCoords | null>(null);
   const [role, setRole] = useState<RolInfo | null>(null);
   const [step, setStep] = useState<"map" | "role" | "enviro" | "sim">("map");
+  const [modo, setModo] = useState<ModoSimulador | null>(null);
 
-  const handleStart = () => {
+  const handleStart = (modoElegido: ModoSimulador) => {
     setShowDashboard(false);
     resetSimulacro();
     setDerrCoords(null);
     setRole(null);
     setStep("map");
+    setModo(modoElegido);
   };
 
   const handleReset = () => {
@@ -44,12 +66,19 @@ export default function LandingSimulacro() {
     setDerrCoords(null);
     setRole(null);
     setStep("map");
+    setModo(null);
   };
 
   // Renderiza Dashboard si corresponde
   if (showDashboard) {
     return <Dashboard onStart={handleStart} />;
   }
+
+  // Filtrado de roles según modo
+  const rolesFiltrados =
+    modo === "entrenamiento"
+      ? ROLES_INFO.filter((r) => ROLES_ENTRENAMIENTO.includes(r.code))
+      : ROLES_INFO.filter((r) => ROLES_SIMULACRO.includes(r.code));
 
   // Flujo paso a paso
   return (
@@ -75,7 +104,7 @@ export default function LandingSimulacro() {
       {step === "role" && (
         <div>
           <RoleDropdown
-            roles={ROLES_INFO}
+            roles={rolesFiltrados}
             selectedRole={role}
             onChange={setRole}
           />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -608,6 +608,10 @@ textarea:focus {
   margin-top: 2rem;
 }
 
+.dashboard-modos {
+  margin-bottom: 1.5rem;
+}
+
 /* Timeline visual de fases del simulacro */
 .timeline-bar {
   width: 100%;

--- a/src/types/dualidad.ts
+++ b/src/types/dualidad.ts
@@ -1,0 +1,2 @@
+// src/types/dualidad.ts
+export type ModoSimulador = "entrenamiento" | "simulacro";


### PR DESCRIPTION
…es filtrados

- Añadido selector de modo en el Dashboard para elegir entre "Entrenamiento" y "Simulacro real/Coordinación".
- El flujo de la app se adapta al modo seleccionado, mostrando solo los roles permitidos en cada caso:
- Entrenamiento: solo roles operativos reales.
- Simulacro: solo roles de observador, organizador y líder de simulacro. -Refactorizado el flujo principal y el selector de roles para soportar la dualidad.
- Añadida documentación y tipos para el modo de simulador. Mejorada la experiencia de usuario y la claridad del flujo inicial.